### PR TITLE
Use mb_strlen to get strings length.

### DIFF
--- a/src/Base/Strings.php
+++ b/src/Base/Strings.php
@@ -70,6 +70,6 @@ class Strings extends ValueObject
      */
     public function length(): int
     {
-        return strlen($this->value);
+        return mb_strlen($this->value);
     }
 }

--- a/tests/Base/StringsTest.php
+++ b/tests/Base/StringsTest.php
@@ -56,4 +56,13 @@ class StringsTest extends TestCase
         $this->assertEquals(" The string ", $stringNotTrimmed);
         $this->assertEquals("The string", $stringTrimmed);
     }
+
+
+    public function testStringsWorkAlsoWithMultiByte()
+    {
+        $multiBytes = "Pîns grøw with fó®†une!";
+        $strings = new Strings($multiBytes);
+
+        $this->assertEquals(mb_strlen($multiBytes), $strings->length());
+    }
 }


### PR DESCRIPTION
Strings::length() method was using strlen.